### PR TITLE
fix: candidate extract json path

### DIFF
--- a/llm-logging/llm-extract-candidates-v1/sharedflowbundle/policies/EV-ExtractCandidateContents.xml
+++ b/llm-logging/llm-extract-candidates-v1/sharedflowbundle/policies/EV-ExtractCandidateContents.xml
@@ -17,7 +17,7 @@
   <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
   <JSONPayload>
     <Variable name="candidate_parts" type="string">
-      <JSONPath>$.[*].candidates[*].content.parts[*].text</JSONPath>
+      <JSONPath>$.candidates[*].content.parts[*].text</JSONPath>
     </Variable>
   </JSONPayload>
   <Source clearPayload="false">response</Source>


### PR DESCRIPTION
The payload for generateContent looks like this now 
![image](https://github.com/user-attachments/assets/f18c53e6-a860-4d23-93f0-22d70e2d5192)

i.e. root is an object and candidates are present in that object, root is no longer a list.

$.[*].candidates[*].content.parts[*].text

This was returning an empty list 
![image](https://github.com/user-attachments/assets/7e99ddce-2b7d-490b-85b2-9aef2877bf60)


because extract candidate policy was returning an empty list


![image](https://github.com/user-attachments/assets/215f0406-97ce-4d22-97ec-f6bae9c68b93)


![image](https://github.com/user-attachments/assets/df83ad7c-10eb-4db4-9806-970f67e4ab4d)
