### PR TITLE
fix: Model URL

### DIFF
--- a/llm-semantic-cache/apiproxy/proxies/default.xml
+++ b/llm-semantic-cache/apiproxy/proxies/default.xml
@@ -30,7 +30,7 @@
           <Name>FC-SemanticCacheResponse</Name>
         </Step>
       </Response>
-      <Condition>(proxy.pathsuffix MatchesPath "/v1/projects/*/locations/*/publishers/google/models/*") and (request.verb = "POST")</Condition>
+      <Condition>(proxy.pathsuffix MatchesPath "/v1*/projects/*/locations/*/publishers/google/models/*") and (request.verb = "POST")</Condition>
     </Flow>
   </Flows>
   <PostFlow name="PostFlow">


### PR DESCRIPTION
When we use VertexAI model, it's now making call to 

/v1beta1/projects/*/locations/*/publishers/google/models/*

instead of 

/v1/projects/*/locations/*/publishers/google/models/*


![Screenshot 2025-03-04 12 05 08 AM](https://github.com/user-attachments/assets/f287de24-d107-4ac6-92f0-d3c54f269d6f)


This leads to FC-SemanticCacheRequest and FC-SemanticCacheResponse policies getting skipped.
